### PR TITLE
Fix absolute path issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ title: Good Clean Read
 tag_text: Good Clean Read
 description: A responsive template for publishing single-page websites, articles that are easy on the eyes
 url: "http://127.0.0.1:4000"
+baseurl: ""
 
 font-awesome-include: true # make this false if you don't need font-awesome
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,13 +6,13 @@
   <meta name="description" content="{{ site.description }}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ site.title }}</title>
-  <link rel="stylesheet" href="/css/normalize.css">
-  <link rel="stylesheet" href="/css/solo.css">
-  <link rel="stylesheet" href="/css/syntax.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/css/normalize.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/css/solo.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/css/syntax.css">
   {% if site.font-awesome-include %}<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">{% endif %}
-  <link rel="stylesheet" href="/css/rrssb.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/css/rrssb.css">
 
-  <script src="/scripts/jquery.js"></script>
+  <script src="{{ site.baseurl }}/scripts/jquery.js"></script>
   <link rel="canonical" href="{{ site.ull }}" />
 </head>
 <body>
@@ -22,6 +22,6 @@
     {{ content }}
     </div>
   </article>
-<script src="{{ site.url }}/scripts/rrssb.min.js"></script>
+<script src="{{ site.baseurl }}/scripts/rrssb.min.js"></script>
 </body>
 </html>

--- a/index.md
+++ b/index.md
@@ -53,7 +53,7 @@ If you need them, you can stick any of the [605 icons](http://fontawesome.io/ico
 
 Images play nicely with this template as well. Add diagrams or charts to make your point, and the template will fit them in appropriately.
 
-<img src="/images/hello.svg" alt="sample image">
+<img src="images/hello.svg" alt="sample image">
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 


### PR DESCRIPTION
The original work used absolute path and did not specify `baseurl`. If the original work is used as a project page (whose root is a directory under the second level domain name), stylesheets and images cannot be displayed properly.
